### PR TITLE
current: show timeline layout, fix timeline border margin

### DIFF
--- a/components/Directory.js
+++ b/components/Directory.js
@@ -13,11 +13,11 @@ import TimelineDot from "../components/icons/TimelineDot";
 import dayjs from "dayjs";
 import ProjectCard from "../components/ProjectCard";
 
-export default function Directory({ search, title, markdown, posts, columns, timeline = false }) {
+export default function Directory({ search, title, markdown, posts, columns, timeline = false, sort = "reverse" }) {
     const router = useRouter();
 
     const dateGroup = timeline ? posts.reduce((groups, post) => {
-        const month = dayjs(post.date).startOf('month').toISOString()
+        const month = dayjs(post.date || post.end_date).startOf('month').toISOString()
         if (!groups[month]) {
             groups[month] = [];
         }
@@ -55,28 +55,32 @@ export default function Directory({ search, title, markdown, posts, columns, tim
                     </Sidebar>
                 </div>
                 {/* Content */}
-                <div className={cn("col-span-full md:col-start-4 md:col-end-11 lg:col-end-9 mt-16 md:mt-0 markdown", {
-                    "border-l border-dashed pl-8 border-wall-400": timeline
-                })}>
+                <div className={cn("col-span-full md:col-start-4 md:col-end-11 lg:col-end-9 mt-16 md:mt-0 markdown")}>
                     {markdown && <Markdown.render content={JSON.parse(markdown)} />}
-                    {timeline ? Object.entries(dateGroup).sort(([dayA,], [dayB,]) => {
-                        return new Date(dayB) - new Date(dayA)
-                    }).map(([date, content]) => {
-                        return <div key={date} className="relative my-24">
-                            <h2 className="!mt-0" id={date}>{dateToDa(new Date(date))}</h2>
-                            <TimelineDot className="absolute top-2 -left-[2.58rem]" />
-                            {content.map((post) => {
-                                return <ProjectCard key={post.title} cols={["date", "contributors"]} project={post} />
-                            })}
-                        </div>
-                    })
-                        : <>
-                            <h2>Projects</h2>
-                            {posts.map((post) => {
-                                return <ProjectCard key={post.title} project={post} />
-                            })}
-                        </>
-                    }
+                    <div className={cn({ "border-l-hack pl-8 relative mt-16": timeline })}>
+                        {timeline ? Object.entries(dateGroup).sort(([dayA,], [dayB,]) => {
+                            if (sort === "reverse") {
+                                return new Date(dayB) - new Date(dayA)
+                            } else {
+                                return new Date(dayA) - new Date(dayB)
+                            }
+                        }).map(([date, content]) => {
+                            return <div key={date} className="relative my-24">
+                                <h2 className="!mt-0" id={date}>{dateToDa(new Date(date))}</h2>
+                                <TimelineDot className="absolute top-2 -left-[2.58rem] z-10" />
+                                {content.map((post) => {
+                                    return <ProjectCard key={post.title} cols={["date", "contributors"]} project={post} />
+                                })}
+                            </div>
+                        })
+                            : <>
+                                <h2>Projects</h2>
+                                {posts.map((post) => {
+                                    return <ProjectCard key={post.title} project={post} />
+                                })}
+                            </>
+                        }
+                    </div>
                     {nextDir && <Pagination dir={nextDir} />}
                 </div>
                 {/* Table of contents */}

--- a/components/Directory.js
+++ b/components/Directory.js
@@ -57,7 +57,7 @@ export default function Directory({ search, title, markdown, posts, columns, tim
                 {/* Content */}
                 <div className={cn("col-span-full md:col-start-4 md:col-end-11 lg:col-end-9 mt-16 md:mt-0 markdown")}>
                     {markdown && <Markdown.render content={JSON.parse(markdown)} />}
-                    <div className={cn({ "border-l-hack pl-8 relative mt-16": timeline })}>
+                    <div className={cn("mt-16", { "border-l-hack pl-8 relative": timeline })}>
                         {timeline ? Object.entries(dateGroup).sort(([dayA,], [dayB,]) => {
                             if (sort === "reverse") {
                                 return new Date(dayB) - new Date(dayA)

--- a/components/ProjectCard.js
+++ b/components/ProjectCard.js
@@ -58,7 +58,7 @@ export default function ProjectCard({ project, cols = ["duration", "start_date",
                             </div>
                         }
                     })}
-                    {project?.spec && <div className="grow ml-4">
+                    {project?.spec && <div className="grow">
                         <a className="!font-semibold !text-xs text-green-400 block w-fit !leading-none"
                             onClick={(e) => stopAndNavigate(e, project.spec, true)}>
                             SPEC

--- a/pages/current.js
+++ b/pages/current.js
@@ -10,6 +10,8 @@ export default function Current({ markdown, search, posts }) {
             posts={posts}
             title="Current Projects"
             columns={["owner", "end_date"]}
+            timeline
+            sort="forward"
         />
     )
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -25,3 +25,10 @@ a:hover {
 .markdown a {
   @apply break-words;
 }
+
+.border-l-hack::after {
+  @apply border-l border-dashed border-wall-400 absolute top-4 z-0;
+  height: calc(100% - 1rem);
+  left: -1px;
+  content: "";
+}


### PR DESCRIPTION
- Adds a weird hack for cutting the border off 1rem from the top for the timeline to intersect with the dot.
- Adds sort as a possible prop for timeline sorting, so you can choose reverse or forward chronology
- Falls back to `end_date` on Timeline layout if `post.date` is blank
- Sets the timeline layout as the layout for the Current Projects directory